### PR TITLE
Add -y to gitlab install command

### DIFF
--- a/gitlab/cloud-config.yaml
+++ b/gitlab/cloud-config.yaml
@@ -21,7 +21,7 @@ runcmd:
     - 'echo "postfix postfix/protocols       select  all" | sudo debconf-set-selections'
     - 'apt-get install postfix -y'
     - 'curl https://packages.gitlab.com/install/repositories/gitlab/gitlab-ee/script.deb.sh | sudo bash'
-    - 'EXTERNAL_URL="https://$(hostname --fqdn)" apt-get install gitlab-ee'
+    - 'EXTERNAL_URL="https://$(hostname --fqdn)" apt-get install gitlab-ee -y'
     - 'ufw default deny incoming'
     - 'ufw allow OpenSSH'
     - 'ufw allow http'


### PR DESCRIPTION
Cloud init does not install gitlab as it waits for user confirmation and thus the install command gets aborted.
```
The following NEW packages will be installed:
gitlab-ee libgdbm-compat4 libperl5.30 perl perl-modules-5.30
The following packages will be upgraded:
perl-base
1 upgraded, 5 newly installed, 0 to remove and 131 not upgraded.
Need to get 1,254 MB of archives.
After this operation, 3,516 MB of additional disk space will be used.
Do you want to continue? [Y/n] Abort.
```