### PR TITLE
wait 1 minute before applying the firewall (plesk)

### DIFF
--- a/plesk/cloud-config.yaml
+++ b/plesk/cloud-config.yaml
@@ -12,5 +12,6 @@ runcmd:
     - chmod 755 /usr/local/bin/plesk-installer
     - /usr/local/bin/plesk-installer install plesk --preset Recommended --with psa-firewall
     - /usr/local/psa/bin/init_conf --init -hostname $(hostname --fqdn) -passwd {{{params.pleskpassword | escape.shell }}} -email {{params.email}} -trial_license true -license_agreed true
+    - /usr/bin/sleep 60
     - /usr/local/psa/bin/modules/firewall/settings -e
     - /usr/local/psa/bin/modules/firewall/settings -c


### PR DESCRIPTION
It seems like loading the firewall directly after the init_conf command is causing a problem where all connections to the server are lost. as some processes still running in the background. Setting up a sleep 60 before enabling the fire seems to resolve this issue.