### PR TITLE
install firewall separately one plesk one-click-installer

### DIFF
--- a/plesk/cloud-config.yaml
+++ b/plesk/cloud-config.yaml
@@ -10,7 +10,11 @@ packages:
 runcmd:
     - 'curl -o /usr/local/bin/plesk-installer https://autoinstall.plesk.com/plesk-installer'
     - chmod 755 /usr/local/bin/plesk-installer
-    - /usr/local/bin/plesk-installer install plesk --preset Recommended --with psa-firewall
+    - /usr/local/bin/plesk-installer install plesk --preset Recommended
     - /usr/local/psa/bin/init_conf --init -hostname $(hostname --fqdn) -passwd {{{params.pleskpassword | escape.shell }}} -email {{params.email}} -trial_license true -license_agreed true
+    - /usr/local/bin/plesk-installer add plesk --components psa-firewall 
+    - /usr/local/bin/plesk-installer add plesk --components letsencrypt
+    - /usr/local/bin/plesk-installer add plesk --components sslit
+    - /usr/sbin/plesk bin extension --exec letsencrypt cli.php --secure-plesk -d $(hostname --fqdn) -w /var/www/vhosts/default/htdocs -m {{params.email}}
     - /usr/local/psa/bin/modules/firewall/settings -e
     - /usr/local/psa/bin/modules/firewall/settings -c


### PR DESCRIPTION
Plesk has converted the firewall module to an extension on versions 18.0.25 https://docs.plesk.com/release-notes/obsidian/change-log/#plesk-18052