### PR TITLE
Create swap-file for Wordpress server

### DIFF
--- a/wordpress/cloud-config.yaml
+++ b/wordpress/cloud-config.yaml
@@ -4,6 +4,10 @@
 
 {{>users}}
 
+swap:
+  filename: /.swapfile
+  size: 1073741824
+
 packages:
     - apache2
     - php8.3-fpm


### PR DESCRIPTION
Add a 1G swapfile to work better on low ram specced servers.
